### PR TITLE
QemuOpenBoardPkg: Clean up memory detection

### DIFF
--- a/Platform/Qemu/QemuOpenBoardPkg/PlatformInitPei/PlatformInit.h
+++ b/Platform/Qemu/QemuOpenBoardPkg/PlatformInitPei/PlatformInit.h
@@ -10,13 +10,13 @@
 #include <PiPei.h>
 #include <Uefi.h>
 
-#define PIIX4_PCI_IO_BASE 0xC000
-#define PIIX4_PCI_IO_SIZE 0x4000
+#define PIIX4_PCI_IO_BASE  0xC000
+#define PIIX4_PCI_IO_SIZE  0x4000
 
-#define Q35_PCI_IO_BASE 0x6000
-#define Q35_PCI_IO_SIZE 0xA000
+#define Q35_PCI_IO_BASE  0x6000
+#define Q35_PCI_IO_SIZE  0xA000
 
-#define PCI_MMIO_TOP_ADDRESS 0xFC000000
+#define PCI_MMIO_TOP_ADDRESS  0xFC000000
 
 EFI_STATUS
 EFIAPI
@@ -25,11 +25,11 @@ PlatformInit (
   IN CONST EFI_PEI_SERVICES     **PeiServices
   );
 
-UINT64
+UINT32
 EFIAPI
 GetMemoryBelow4Gb (
   VOID
-);
+  );
 
 EFI_STATUS
 EFIAPI
@@ -51,8 +51,8 @@ InitializePciPIIX4 (
 
 EFI_STATUS
 EFIAPI
-MaxCpuInit(
+MaxCpuInit (
   VOID
-);
+  );
 
 #endif


### PR DESCRIPTION
Check if we have enough memory to do our reservations, clean up DEBUG's,
fix GetMemoryBelow4Gb()'s return type.

Signed-off-by: Pedro Falcato <pedro.falcato@gmail.com>