### PR TITLE
edk2-platforms/Maintainers: Add QemuOpenBoardPkg

### DIFF
--- a/Maintainers.txt
+++ b/Maintainers.txt
@@ -359,6 +359,13 @@ M: Leif Lindholm <quic_llindhol@quicinc.com>
 R: Graeme Gregory <graeme@nuviainc.com>
 R: Radoslaw Biernacki <rad@semihalf.com>
 
+QEMU MinPlatform Arch spec based port
+F: Platform/Qemu/QemuOpenBoardPkg/
+F: Silicon/Qemu/QemuOpenBoardPkg/
+M: Isaac Oram <isaac.w.oram@intel.com>
+M: Pedro Falcato <pedro.falcato@gmail.com>
+R: Theo Jehl <theojehl76@gmail.com>
+
 Raspberry Pi platforms and silicon
 F: Platform/RaspberryPi/
 F: Silicon/Broadcom/


### PR DESCRIPTION
Add maintainers and reviewers for MinPlatform Arch QEMU board port.

Cc: Leif Lindholm <quic_llindhol@quicinc.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Isaac Oram <isaac.w.oram@intel.com>
Cc: Pedro Falcato <pedro.falcato@gmail.com>
Cc: Theo Jehl <theojehl76@gmail.com>
Signed-off-by: Isaac Oram <isaac.w.oram@intel.com>